### PR TITLE
DictionaryBase-throws-exception-when-getting-missing-value-#145

### DIFF
--- a/projects/ACore/include/ACore/DictionaryBase.hpp
+++ b/projects/ACore/include/ACore/DictionaryBase.hpp
@@ -16,6 +16,7 @@
 #define ACORE_DICTIONARYBASE_HPP
 
 #include "ACoreModule.hpp"
+#include "Exception.hpp"
 #include "ForwardIterator.hpp"
 #include "Variant.hpp"
 
@@ -247,22 +248,24 @@ public:
     //! then converted to type \c T.
     //!
     //! If \a index does not point to a valid value
-    //! a default constructed T is returned.
+    //! an exception is thrown.
     template<typename T>
     [[nodiscard]] constexpr auto value(size_type index) const -> T
     {
-        T val;
-
         if constexpr (std::is_trivially_copyable<T>::value)
         {
+            T val;
             std::memcpy(&val, &index, sizeof(T));
+            return val;
         }
         else if (contains(index))
         {
-            val = mData.value(index).template value<T>();
+            return mData.value(index).template value<T>();
         }
-
-        return val;
+        else
+        {
+            throw Exception{} << "Index '" << index << "' does not exist in the dictionary.";
+        }
     }
 
 protected:
@@ -320,7 +323,7 @@ private:
     {
         for (index++; index < mData.capacity(); index++)
         {
-            if (mData.value(index).isValid())
+            if (contains(index))
             {
                 return index;
             }

--- a/projects/ACore/test/DictionaryTest.cpp
+++ b/projects/ACore/test/DictionaryTest.cpp
@@ -505,7 +505,7 @@ TEST_CASE("value(size_type index) const -> T [acore::Dictionary]")
     SECTION("[empty]")
     {
         const acore::Dictionary dictionary;
-        REQUIRE(dictionary.value<std::string>(0) == std::string{}); //NOLINT(readability-container-size-empty)
+        REQUIRE_THROWS_AS(dictionary.value<std::string>(0), acore::Exception);
     }
 
     SECTION("[data]")
@@ -535,7 +535,7 @@ TEST_CASE("value(size_type index) const -> T [acore::Dictionary]")
         SECTION("[removed]")
         {
             dictionary.remove(3);
-            REQUIRE(std::as_const(dictionary).value<std::vector<char>>(3) == std::vector<char>{}); //NOLINT(readability-container-size-empty)
+            REQUIRE_THROWS_AS(std::as_const(dictionary).value<std::vector<char>>(3), acore::Exception);
         }
 
         SECTION("[trivial]")

--- a/projects/AFile/PersistentDictionaryData.cpp
+++ b/projects/AFile/PersistentDictionaryData.cpp
@@ -94,14 +94,7 @@ auto PersistentDictionaryData::remove(acore::size_type index, acore::size_type h
 
 auto PersistentDictionaryData::value(acore::size_type index) const -> acore::Variant
 {
-    const acore::size_type valueIndex = mDataIndex[index].valueIndex;
-
-    if (mFile->contains(valueIndex))
-    {
-        return mFile->value<acore::Variant>(mDataIndex[index].valueIndex);
-    }
-
-    return {};
+    return mFile->value<acore::Variant>(mDataIndex[index].valueIndex);
 }
 
 auto PersistentDictionaryData::freeIndex() -> acore::size_type

--- a/projects/AFile/test/PersistentDictionaryTest.cpp
+++ b/projects/AFile/test/PersistentDictionaryTest.cpp
@@ -635,7 +635,7 @@ TEST_CASE("value(size_type index) const -> T [afile::PersistentDictionary]")
     {
         const TestFile testFile;
         const afile::PersistentDictionary dictionary{testFile.file()};
-        REQUIRE(dictionary.value<std::string>(0) == std::string{}); //NOLINT(readability-container-size-empty)
+        REQUIRE_THROWS_AS(dictionary.value<std::string>(0), acore::Exception);
     }
 
     SECTION("[data]")
@@ -666,59 +666,12 @@ TEST_CASE("value(size_type index) const -> T [afile::PersistentDictionary]")
         SECTION("[removed]")
         {
             dictionary.remove(3);
-            REQUIRE(std::as_const(dictionary).value<std::vector<char>>(3) == std::vector<char>{}); //NOLINT(readability-container-size-empty)
+            REQUIRE_THROWS_AS(std::as_const(dictionary).value<std::vector<char>>(3), acore::Exception);
         }
 
         SECTION("[trivial]")
         {
             REQUIRE(std::as_const(dictionary).value<char>('A') == 'A');
-        }
-    }
-}
-
-TEST_CASE("operator[](size_type index) const -> Variant [afile::PersistentDictionary]")
-{
-    SECTION("[empty]")
-    {
-        const TestFile testFile;
-        const afile::PersistentDictionary dictionary{testFile.file()};
-        REQUIRE(dictionary.value<acore::Variant>(0) == acore::Variant{});
-    }
-
-    SECTION("[data]")
-    {
-        const TestFile testFile{std::string{"Hello"},
-                                std::vector<int>{1, 2, 3, 4, 5},
-                                std::string{"Hello"},
-                                std::string{"World"},
-                                std::vector<char>{'a', 'b'}};
-        afile::PersistentDictionary dictionary{testFile.file(), testFile.index()};
-
-        SECTION("[existing]")
-        {
-            REQUIRE(std::as_const(dictionary).value<acore::Variant>(1) == acore::Variant{std::vector<int>{1, 2, 3, 4, 5}});
-        }
-
-        SECTION("[multi]")
-        {
-            REQUIRE(std::as_const(dictionary).value<acore::Variant>(0) == acore::Variant{std::string{"Hello"}});
-        }
-
-        SECTION("[multi removed]")
-        {
-            dictionary.remove(0);
-            REQUIRE(std::as_const(dictionary).value<acore::Variant>(0) == acore::Variant{std::string{"Hello"}});
-        }
-
-        SECTION("[removed]")
-        {
-            dictionary.remove(3);
-            REQUIRE(std::as_const(dictionary).value<acore::Variant>(3) == acore::Variant{});
-        }
-
-        SECTION("[trivial]")
-        {
-            REQUIRE(std::as_const(dictionary).value<acore::Variant>('A') == acore::Variant{});
         }
     }
 }


### PR DESCRIPTION
Also remove obsolete TEST_CASE from PersistentDictionaryTest

# Description

Changes DictionaryBase::value to throw an exception when the index of a complex value is not in the dictionary.

Resolves #145
