### PR TITLE
Use Ubuntu 20.04

### DIFF
--- a/.github/workflows/ADev.yml
+++ b/.github/workflows/ADev.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analysis:
     name: Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ninja
@@ -23,7 +23,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ninja
@@ -49,7 +49,7 @@ jobs:
 
   documentation:
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Doxygen
@@ -64,7 +64,7 @@ jobs:
 
   formatting:
     name: Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Clang-Format
@@ -74,7 +74,7 @@ jobs:
 
   sanitize-address:
     name: Sanitize Address
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ninja
@@ -90,7 +90,7 @@ jobs:
 
   sanitize-memory:
     name: Sanitize Memory
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ninja
@@ -106,7 +106,7 @@ jobs:
 
   sanitize-ub:
     name: Sanitize Undefined Behavior
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Ninja
@@ -134,7 +134,7 @@ jobs:
             }
           - {
               name: "Linux GCC x64",
-              os: ubuntu-latest,
+              os: ubuntu-20.04,
               platform: linux-gcc9-x64,
             }
           - {

--- a/.github/workflows/ADev.yml
+++ b/.github/workflows/ADev.yml
@@ -140,7 +140,7 @@ jobs:
           - {
               name: "macOS Clang x64",
               os: macos-latest,
-              platform: macOS-clang9-x64,
+              platform: macOS-clang11-x64,
             }
     steps:
       - uses: actions/checkout@v2

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 # ADev Build Script #
 #####################
 ACTION=$1
-GCC_VERSION=9
+GCC_VERSION=10
 LLVM_VERSION=10
 
 function printHelp () {
@@ -91,17 +91,11 @@ function isAvailable () {
 #############
 # INSTALL-* #
 #############
-function addLLVMRepository () {
-    sudo apt-get update -y
-    sudo apt-get install -y software-properties-common
-    sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${LLVM_VERSION} main"
-}
-
 function installClang () {
     if isWindows; then
         choco install -y llvm
     elif isLinux; then
-        addLLVMRepository
+        sudo apt-get update -y
         sudo apt-get install -y clang-${LLVM_VERSION} clang++-${LLVM_VERSION}
     else
         brew install llvm
@@ -112,7 +106,7 @@ function installClangFormat () {
     if isWindows; then
         choco install -y llvm
     elif isLinux; then
-        addLLVMRepository
+        sudo apt-get update -y
         sudo apt-get install -y clang-format-${LLVM_VERSION}
     else
         brew install clang-format
@@ -123,7 +117,7 @@ function installClangTidy () {
     if isWindows; then
         choco install -y llvm
     elif isLinux; then
-        addLLVMRepository
+        sudo apt-get update -y
         sudo apt-get install -y clang-tidy-${LLVM_VERSION}
     else
         brew install llvm
@@ -134,7 +128,7 @@ function installCMake () {
     if isWindows; then
         choco install -y cmake
     elif isLinux; then
-        addLLVMRepository
+        sudo apt-get update -y
         sudo apt-get install -y cmake
     else
         brew install cmake
@@ -165,7 +159,7 @@ function installLLVM () {
     if isWindows; then
         choco install -y llvm
     elif isLinux; then
-        addLLVMRepository
+        sudo apt-get update -y
         sudo apt-get install -y llvm-10
     else
         brew install llvm


### PR DESCRIPTION
# Description

Use Ubuntu 20.04 instead of ubuntu-latest to use more recent packages (GCC and Doxygen) because bugs in the older versions.

Resolves #152
