### PR TITLE
Add string_view support

### DIFF
--- a/projects/ACore/include/ACore/DataStreamBase.hpp
+++ b/projects/ACore/include/ACore/DataStreamBase.hpp
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <initializer_list>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -458,6 +459,21 @@ auto operator>>(DataStreamBase<Buffer> &stream, double &value) -> DataStreamBase
 }
 
 //! \relates DataStreamBase
+//! Serializes contents of the std::string_view
+//! \a value into the stream as acore::size_type
+//! value representing the string's size obtained
+//! by the call to \c size() followed by the string
+//! data. Returns the \a stream.
+template<typename Buffer>
+auto operator<<(DataStreamBase<Buffer> &stream, const std::string_view &value) -> DataStreamBase<Buffer> &
+{
+    const auto size = static_cast<size_type>(value.size());
+    stream << size;
+    stream.write(value.data(), size);
+    return stream;
+}
+
+//! \relates DataStreamBase
 //! Serializes a null terminated c-string \a value
 //! into the stream as \c std::int64_t value representing
 //! the string's size obtained by the call to \c strlen()
@@ -473,24 +489,7 @@ auto operator>>(DataStreamBase<Buffer> &stream, double &value) -> DataStreamBase
 template<typename Buffer>
 auto operator<<(DataStreamBase<Buffer> &stream, const char *value) -> DataStreamBase<Buffer> &
 {
-    const auto size = static_cast<size_type>(std::strlen(value));
-    stream << size;
-    stream.write(value, size);
-    return stream;
-}
-
-//! \relates DataStreamBase
-//! Serializes an std::string \a value into the stream
-//! as acore::size_type value representing the string's
-//! size obtained by the call to \c size() followed
-//! by the string data. Returns the \a stream.
-template<typename Buffer>
-auto operator<<(DataStreamBase<Buffer> &stream, const std::string &value) -> DataStreamBase<Buffer> &
-{
-    const auto size = static_cast<size_type>(value.size());
-    stream << size;
-    stream.write(value.data(), size);
-    return stream;
+    return stream << std::string_view{value};
 }
 
 //! \relates DataStreamBase

--- a/projects/ACore/include/ACore/Variant.hpp
+++ b/projects/ACore/include/ACore/Variant.hpp
@@ -19,6 +19,7 @@
 #include "Exception.hpp"
 
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -48,6 +49,18 @@ public:
     explicit constexpr Variant(const T &value)
     {
         mStream << value;
+    }
+
+    //! Constructs a Variant from \c std::string_view \a value.
+    explicit Variant(std::string_view value) :
+        mStream{std::vector<char>(value.begin(), value.end())}
+    {
+    }
+
+    //! Constructs a Variant from raw \c c-string \a value.
+    explicit Variant(const char *value) :
+        Variant(std::string_view{value})
+    {
     }
 
     //! Constructs a Variant from raw data vector \a value.
@@ -129,7 +142,7 @@ private:
 //! Constructs a Variant from \c string \a value.
 template<>
 inline Variant::Variant(const std::string &value) :
-    mStream{std::vector<char>(value.begin(), value.end())}
+    Variant(std::string_view{value})
 {
 }
 
@@ -147,6 +160,14 @@ template<>
 inline auto Variant::value() const -> std::string
 {
     return std::string(mStream.buffer().data().begin(), mStream.buffer().data().end());
+}
+
+//! Explicit specialization returning the copy
+//! of the underlying data as a string.
+template<>
+inline auto Variant::value() const -> std::string_view
+{
+    return std::string_view(&mStream.buffer().data()[0], mStream.buffer().data().size());
 }
 
 //! Explicit specialization returning the copy

--- a/projects/ACore/test/DataStreamTest.cpp
+++ b/projects/ACore/test/DataStreamTest.cpp
@@ -231,7 +231,7 @@ TEST_CASE("operator<<(DataStream &stream, const T &value) -> DataStream &, opera
         REQUIRE(j == std::numeric_limits<std::int64_t>::min());
     }
 
-    SECTION("const char*, std::string")
+    SECTION("const char*, std::string_view")
     {
         const std::string str1{"Hello World!"};
         const std::string str2;

--- a/projects/ACore/test/VariantTest.cpp
+++ b/projects/ACore/test/VariantTest.cpp
@@ -34,14 +34,21 @@ TEST_CASE("[acore::Variant]")
 
 TEST_CASE("Variant() [acore::Variant]")
 {
-    const acore::Variant variant;
-    REQUIRE(variant.value<const std::vector<char> &>() == std::vector<char>{}); //NOLINT(readability-container-size-empty)
+    REQUIRE_NOTHROW(acore::Variant{});
 }
 
 TEST_CASE("Variant(const T &value) [acore::Variant]")
 {
-    const acore::Variant variant{std::vector<int>{1, 2}};
-    REQUIRE(variant.value<const std::vector<char> &>().size() == 16);
+    SECTION("[complex]")
+    {
+        REQUIRE_NOTHROW(acore::Variant{std::vector<int>{1, 2}});
+    }
+
+    SECTION("[string_view]")
+    {
+        const char *value = "Hello, World!";
+        REQUIRE_NOTHROW(acore::Variant{std::string_view{value}});
+    }
 }
 
 TEST_CASE("isValid() const noexcept -> bool [acore::Variant]")
@@ -72,6 +79,20 @@ TEST_CASE("value() const -> T [acore::Variant]")
     {
         const acore::Variant variant{std::string{"Hello World!"}};
         REQUIRE(variant.value<std::string>() == "Hello World!");
+    }
+
+    SECTION("[string_view]")
+    {
+        const std::string value = "Hello, World!";
+        const acore::Variant variant{std::string_view{value}};
+        REQUIRE(variant.value<std::string_view>() == value);
+    }
+
+    SECTION("[raw string to string]")
+    {
+        const char *value = "Hello, World!";
+        const acore::Variant variant{value};
+        REQUIRE(variant.value<std::string>() == std::string{value});
     }
 
     SECTION("[raw data]")


### PR DESCRIPTION
# Description

Adds support for std::string_view to acore::Variant and acore::DataStreamBase.

Resolves #170 
