### PR TITLE
Add recursive query data binding

### DIFF
--- a/projects/ADb/Query.cpp
+++ b/projects/ADb/Query.cpp
@@ -29,4 +29,71 @@ auto select() -> Query::Select
 {
     return Query::Select{};
 }
+
+auto Query::bind(std::string_view name, PlaceholderValue value) & -> void //NOLINT(performance-unnecessary-value-param)
+{
+    const auto placeholder = findPlaceholder(name);
+
+    if (placeholder.bind == nullptr)
+    {
+        throw acore::Exception{} << "Placeholder '" << name << "' not found.";
+    }
+
+    placeholder.bind(std::move(value), placeholder.queryData);
+}
+
+auto Query::addPlaceholder(std::string placeholder, BindPlaceholderFunction bindFunction) -> void
+{
+    validatePlaceholder(placeholder);
+    mPlaceholders.emplace_back(PlaceholderData{std::move(placeholder), bindFunction});
+}
+
+auto Query::addSubQuery(Query &&query, BindResultFunction bindFunction) -> void
+{
+    for (const auto &placeholder : query.mPlaceholders)
+    {
+        validatePlaceholder(placeholder.name);
+    }
+
+    mSubQueries.emplace_back(SubQuery{std::move(query), bindFunction});
+}
+
+auto Query::findPlaceholder(std::string_view name) -> PlaceholderBind
+{
+    for (const auto &subQuery : mSubQueries)
+    {
+        const auto placeholder = subQuery.query()->findPlaceholder(name);
+
+        if (placeholder.bind != nullptr)
+        {
+            return placeholder;
+        }
+    }
+
+    for (const auto &placeholder : mPlaceholders)
+    {
+        if (placeholder.name == name)
+        {
+            return {placeholder.bind, &mData};
+        }
+    }
+
+    return {};
+}
+
+auto Query::validatePlaceholder(std::string_view name) const -> void
+{
+    for (const auto &subQuery : mSubQueries)
+    {
+        subQuery.query()->validatePlaceholder(name);
+    }
+
+    for (const auto &placeholder : mPlaceholders)
+    {
+        if (placeholder.name == name)
+        {
+            throw acore::Exception{} << "Placeholder '" << name << "' already exists.";
+        }
+    }
+}
 }

--- a/projects/ADb/include/ADb/Query.hpp
+++ b/projects/ADb/include/ADb/Query.hpp
@@ -57,19 +57,7 @@ public:
     //! \a value 's type does not match the type
     //! expected by the placeholding value an exception
     //! is thrown.
-    auto bind(std::string_view name, PlaceholderValue value) & -> void //NOLINT(performance-unnecessary-value-param)
-    {
-        const auto it = std::find_if(mPlaceholders.begin(), mPlaceholders.end(), [&](const auto &placeholder) {
-            return placeholder.name == name;
-        });
-
-        if (it == mPlaceholders.end())
-        {
-            throw acore::Exception{} << "Placeholder '" << name << "' not found.";
-        }
-
-        it->bind(std::move(value), &mData);
-    }
+    auto bind(std::string_view name, PlaceholderValue value) & -> void;
 
     //! Convenience overload for binding a list of
     //! element ids.
@@ -136,24 +124,16 @@ private:
     {
     }
 
-    auto addPlaceholder(std::string placeholder, BindPlaceholderFunction bindFunction) -> void
+    struct PlaceholderBind
     {
-        const auto it = std::find_if(mPlaceholders.begin(), mPlaceholders.end(), [&](const auto &p) {
-            return p.name == placeholder;
-        });
+        BindPlaceholderFunction bind = nullptr;
+        QueryData *queryData = nullptr;
+    };
 
-        if (it != mPlaceholders.end())
-        {
-            throw acore::Exception{} << "Placeholder '" << placeholder << "' already exists.";
-        }
-
-        mPlaceholders.emplace_back(PlaceholderData{std::move(placeholder), bindFunction});
-    }
-
-    auto addSubQuery(Query &&query, BindResultFunction bindFunction) -> void
-    {
-        mSubQueries.emplace_back(SubQuery{std::move(query), bindFunction});
-    }
+    auto addPlaceholder(std::string placeholder, BindPlaceholderFunction bindFunction) -> void;
+    auto addSubQuery(Query &&query, BindResultFunction bindFunction) -> void;
+    [[nodiscard]] auto findPlaceholder(std::string_view name) -> PlaceholderBind;
+    auto validatePlaceholder(std::string_view name) const -> void;
 
     QueryData mData;
     std::vector<PlaceholderData> mPlaceholders;


### PR DESCRIPTION
# Description

Add recursive binding (to subqueries) via query's bind method. Also add check when adding subquery that throws an exception in case there are duplicate placeholder names already in the query hierarchy.

Resolves #231 
