### PR TITLE
[atest] Fix using templated function such as toThrow() requires template keyword #392

### DIFF
--- a/projects/atest/README.md
+++ b/projects/atest/README.md
@@ -227,7 +227,6 @@ It is also a requirement for all values used in the expectations and matching to
 
 ### Affects Users
 
--   Using templated function such as `toThrow` (e.g. `expect([] { throw 1; }).toThrow<int>();` does not work and requires `template` keyword (e.g. `expect([] { throw 1; }).template toThrow<int>();`) otherwise parser fails: Reported bug: https://developercommunity.visualstudio.com/t/Cannot-instantiate-template-exported-fro/1387974
 -   Using `clang-tidy` with global calls to `suite()` will result in incorrect `cert-err58-cpp` warning being emitted stating that the function may throw and there is no possibility to catch the exception. The function is however declared `noexcept` and its body is wrapped in `try {} catch (...) {}` therefore it cannot actually throw any exceptions. It indicates succes by returning `0` and failure (an exception) byt returing `1`. To avoid this you need either to add `//NOLINT(cert-err58-cpp)` to the line where you call `suite()` or call `suite()` directly or indirectly from `main()` only (but the second option loses the self-registering property of the suites).
 
 ### Does Not Affect Users

--- a/projects/atest/test/expect_tothrow_test.cpp
+++ b/projects/atest/test/expect_tothrow_test.cpp
@@ -9,23 +9,23 @@ using atest::test;
 
 static const auto s = suite("Expect::toThrow()", [] { //NOLINT(cert-err58-cpp)
     test("Exception types match", [] {
-        expect([] { throw std::logic_error{""}; }).template toThrow<std::logic_error>();
+        expect([] { throw std::logic_error{""}; }).toThrow<std::logic_error>();
     });
 
     test("Exception types mismatch", [] {
-        expect_fail([] { throw std::runtime_error{""}; }).template toThrow<std::logic_error>();
+        expect_fail([] { throw std::runtime_error{""}; }).toThrow<std::logic_error>();
     });
 
     test("Exception types mismatch: expect base, throw derived", [] {
-        expect_fail([] { throw std::runtime_error{""}; }).template toThrow<std::exception>();
+        expect_fail([] { throw std::runtime_error{""}; }).toThrow<std::exception>();
     });
 
     test("Exception types mismatch: throw int", [] {
-        expect_fail([] { throw 1; }).template toThrow<std::exception>();
+        expect_fail([] { throw 1; }).toThrow<std::exception>();
     });
 
     test("Exception text match", [] {
-        expect([] { throw std::runtime_error{"Some exception text"}; }).template toThrow<std::runtime_error>("Some exception text");
+        expect([] { throw std::runtime_error{"Some exception text"}; }).toThrow<std::runtime_error>("Some exception text");
     });
 
     test("Exception text match: int", [] {
@@ -33,7 +33,7 @@ static const auto s = suite("Expect::toThrow()", [] { //NOLINT(cert-err58-cpp)
     });
 
     test("Exception text mismatch", [] {
-        expect_fail([] { throw std::runtime_error{"Some exception text"}; }).template toThrow<std::runtime_error>("Some different exception text");
+        expect_fail([] { throw std::runtime_error{"Some exception text"}; }).toThrow<std::runtime_error>("Some different exception text");
     });
 
     test("Exception text mismatch (INTENTIONAL FAILURE)", [] {
@@ -41,15 +41,15 @@ static const auto s = suite("Expect::toThrow()", [] { //NOLINT(cert-err58-cpp)
     });
 
     test("No exception thrown", [] {
-        expect_fail([] {}).template toThrow<std::exception>();
+        expect_fail([] {}).toThrow<std::exception>();
     });
 
     test("No exception thrown (INTENTIONAL FAILURE)", [] {
-        expect([] {}).template toThrow<std::exception>();
+        expect([] {}).toThrow<std::exception>();
     });
 
     test("Exception types match: int", [] {
-        expect([] { throw 1; }).template toThrow<int>();
+        expect([] { throw 1; }).toThrow<int>();
     });
 
     test("Exception value match: int", [] {


### PR DESCRIPTION
Resolves #392 
