### PR TITLE
[abuild] span is not recognized as STL header #469

### DIFF
--- a/projects/abuild/code_scanner.cpp
+++ b/projects/abuild/code_scanner.cpp
@@ -345,7 +345,7 @@ private:
         "set",
         "shared_mutex",
         "source_location",
-        "span:",
+        "span",
         "sstream",
         "stack",
         "stdexcept",


### PR DESCRIPTION
Resolves #469
