### PR TITLE
[abuild] Fix DependencyScanner does not find local headers via double dot #473

### DIFF
--- a/projects/abuild/build_cache_index.cpp
+++ b/projects/abuild/build_cache_index.cpp
@@ -48,7 +48,7 @@ public:
 
         if (!hint.empty())
         {
-            const std::filesystem::path hintedPath = hint / file;
+            const std::filesystem::path hintedPath = (hint / file).lexically_normal();
 
             for (It it = range.first; it != range.second; ++it)
             {
@@ -133,7 +133,7 @@ public:
 
         if (!hint.empty())
         {
-            const std::filesystem::path hintedPath = hint / file;
+            const std::filesystem::path hintedPath = (hint / file).lexically_normal();
 
             for (It it = range.first; it != range.second; ++it)
             {

--- a/projects/abuild/test/header_test.cpp
+++ b/projects/abuild/test/header_test.cpp
@@ -170,4 +170,18 @@ static const auto testSuite = suite("abuild::Header", [] {
         expect(header->path()).toBe(testProject.projectRoot() / "include" / "header.hpp");
         expect(header->project()->name()).toBe("build_test_project_scanner");
     });
+
+    test("lookup header with impossible sequence of ../", [] {
+        TestProject testProject{"build_test_project_scanner",
+                                {"include/header.hpp",
+                                 "include/subdir/myheader.hpp"}};
+
+        abuild::BuildCache cache;
+        cache.addHeader(testProject.projectRoot() / "include" / "header.hpp", "build_test_project_scanner");
+        cache.addHeader(testProject.projectRoot() / "include" / "subdir" / "myheader.hpp", "build_test_project_scanner");
+
+        const abuild::Header *header = cache.header("../../../header.hpp", testProject.projectRoot().root_path());
+
+        expect(header).toBe(nullptr);
+    });
 });

--- a/projects/abuild/test/header_test.cpp
+++ b/projects/abuild/test/header_test.cpp
@@ -154,4 +154,20 @@ static const auto testSuite = suite("abuild::Header", [] {
         expect(header->path()).toBe(testProject.projectRoot() / "include" / "header.hpp");
         expect(header->project()->name()).toBe("build_test_project_scanner");
     });
+
+    test("lookup header with ../", [] {
+        TestProject testProject{"build_test_project_scanner",
+                                {"include/header.hpp",
+                                 "include/subdir/myheader.hpp"}};
+
+        abuild::BuildCache cache;
+        cache.addHeader(testProject.projectRoot() / "include" / "header.hpp", "build_test_project_scanner");
+        cache.addHeader(testProject.projectRoot() / "include" / "subdir" / "myheader.hpp", "build_test_project_scanner");
+
+        const abuild::Header *header = cache.header("../header.hpp", testProject.projectRoot() / "include" / "subdir");
+
+        assert_(header != nullptr).toBe(true);
+        expect(header->path()).toBe(testProject.projectRoot() / "include" / "header.hpp");
+        expect(header->project()->name()).toBe("build_test_project_scanner");
+    });
 });


### PR DESCRIPTION
Resolves #473
